### PR TITLE
[FEAT] Send Result Content

### DIFF
--- a/src/main/java/com/rhkr8521/iccas_question/api/answer/service/AnswerService.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/answer/service/AnswerService.java
@@ -4,6 +4,7 @@ import com.rhkr8521.iccas_question.api.answer.domain.Answer;
 import com.rhkr8521.iccas_question.api.answer.repository.AnswerRepository;
 import com.rhkr8521.iccas_question.api.question.domain.Question;
 import com.rhkr8521.iccas_question.api.question.repository.QuestionRepository;
+import com.rhkr8521.iccas_question.api.result.service.ResultService;
 import com.rhkr8521.iccas_question.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ public class AnswerService {
 
     private final AnswerRepository answerRepository;
     private final QuestionRepository questionRepository;
+    private final ResultService resultService;
 
     @Transactional
     public boolean checkAnswer(Long questionId, String userId, String userAnswer) {
@@ -22,6 +24,8 @@ public class AnswerService {
                 .orElseThrow(() -> new NotFoundException("문제 ID를 찾을 수 없습니다."));
 
         boolean isCorrect = question.getAnswer().equalsIgnoreCase(userAnswer);
+
+        resultService.updateResult(userId, question.getTheme(), question.getStage(), isCorrect);
 
         Answer answer = Answer.builder()
                 .question(question)

--- a/src/main/java/com/rhkr8521/iccas_question/api/result/controller/ResultController.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/controller/ResultController.java
@@ -1,0 +1,32 @@
+package com.rhkr8521.iccas_question.api.result.controller;
+
+import com.rhkr8521.iccas_question.api.result.dto.ResultResponseDTO;
+import com.rhkr8521.iccas_question.api.result.service.ResultService;
+import com.rhkr8521.iccas_question.common.response.ApiResponse;
+import com.rhkr8521.iccas_question.common.response.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ResultController {
+
+    private final ResultService resultService;
+
+    @GetMapping("/api/result/{userId}")
+    public ResponseEntity<?> getResultsByTheme(@PathVariable String userId, @RequestParam String theme) {
+        List<ResultResponseDTO> resultResponseDtos = resultService.getResultsByTheme(userId, theme);
+        return ResponseEntity.ok(ApiResponse.builder()
+                .status(SuccessStatus.SEND_RESULT.getStatusCode())
+                .success(true)
+                .message(SuccessStatus.SEND_RESULT.getMessage())
+                .data(resultResponseDtos)
+                .build());
+    }
+}

--- a/src/main/java/com/rhkr8521/iccas_question/api/result/domain/Result.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/domain/Result.java
@@ -1,0 +1,39 @@
+package com.rhkr8521.iccas_question.api.result.domain;
+
+import com.rhkr8521.iccas_question.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Entity
+@Builder
+public class Result extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String userId;
+
+    private String theme;
+    private Long stage;
+
+    private int totalQuestions;
+    private int totalCorrectAnswers;
+
+    private int recentCorrectAnswers;
+
+    public void incrementTotalQuestions() {
+        this.totalQuestions++;
+    }
+
+    public void incrementTotalCorrectAnswers() {
+        this.totalCorrectAnswers++;
+    }
+
+    public void updateRecentCorrectAnswers(int correctAnswers) {
+        this.recentCorrectAnswers = correctAnswers;
+    }
+}

--- a/src/main/java/com/rhkr8521/iccas_question/api/result/dto/ResultResponseDTO.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/dto/ResultResponseDTO.java
@@ -1,0 +1,15 @@
+package com.rhkr8521.iccas_question.api.result.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResultResponseDTO {
+    private String userId;
+    private String theme;
+    private Long stage;
+    private int totalQuestions;
+    private int totalCorrectAnswers;
+    private int recentCorrectAnswers;
+}

--- a/src/main/java/com/rhkr8521/iccas_question/api/result/repository/ResultRepository.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/repository/ResultRepository.java
@@ -1,0 +1,12 @@
+package com.rhkr8521.iccas_question.api.result.repository;
+
+import com.rhkr8521.iccas_question.api.result.domain.Result;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Optional;
+
+public interface ResultRepository extends JpaRepository<Result, Long> {
+    Optional<Result> findByUserIdAndThemeAndStage(String userId, String theme, Long stage);
+    boolean existsByUserId(String userId);
+    List<Result> findByUserIdAndTheme(String userId, String theme);
+}

--- a/src/main/java/com/rhkr8521/iccas_question/api/result/service/ResultService.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/service/ResultService.java
@@ -1,0 +1,84 @@
+package com.rhkr8521.iccas_question.api.result.service;
+
+import com.rhkr8521.iccas_question.api.result.domain.Result;
+import com.rhkr8521.iccas_question.api.result.dto.ResultResponseDTO;
+import com.rhkr8521.iccas_question.api.result.repository.ResultRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ResultService {
+
+    private final ResultRepository resultRepository;
+
+    @Transactional
+    public List<ResultResponseDTO> getResultsByTheme(String userId, String theme) {
+        return resultRepository.findByUserIdAndTheme(userId, theme).stream()
+                .map(result -> ResultResponseDTO.builder()
+                        .userId(result.getUserId())
+                        .theme(result.getTheme())
+                        .stage(result.getStage())
+                        .totalQuestions(result.getTotalQuestions())
+                        .totalCorrectAnswers(result.getTotalCorrectAnswers())
+                        .recentCorrectAnswers(result.getRecentCorrectAnswers())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void updateResult(String userId, String theme, Long stage, boolean isCorrect) {
+        if (!resultRepository.existsByUserId(userId)) {
+            initializeResult(userId);
+        }
+
+        Result result = resultRepository.findByUserIdAndThemeAndStage(userId, theme, stage)
+                .orElseThrow(() -> new IllegalStateException("Result should be initialized but was not found"));
+
+        result.incrementTotalQuestions();
+        if (isCorrect) {
+            result.incrementTotalCorrectAnswers();
+        }
+
+        int recentCorrectAnswers = result.getRecentCorrectAnswers();
+
+        if (stage == 1L || stage == 2L) {
+            // 10문제 단위로 맞춘 갯수를 갱신
+            if (result.getTotalQuestions() % 10 == 0 && isCorrect) {
+                recentCorrectAnswers = 10;
+            } else if (result.getTotalQuestions() % 10 == 1) {
+                recentCorrectAnswers = isCorrect ? 1 : 0;
+            } else if (isCorrect) {
+                recentCorrectAnswers++;
+            }
+        } else if (stage == 3L) {
+            // 1문제 단위로 맞춘 갯수를 갱신
+            recentCorrectAnswers = isCorrect ? 1 : 0;
+        }
+
+        result.updateRecentCorrectAnswers(recentCorrectAnswers);
+        resultRepository.save(result);
+    }
+
+    @Transactional
+    public void initializeResult(String userId) {
+        List<String> themes = List.of("carousel", "ferris_wheel", "roller_coaster");
+        for (String theme : themes) {
+            for (Long stage = 1L; stage <= 3L; stage++) {
+                Result result = Result.builder()
+                        .userId(userId)
+                        .theme(theme)
+                        .stage(stage)
+                        .totalQuestions(0)
+                        .totalCorrectAnswers(0)
+                        .recentCorrectAnswers(0)
+                        .build();
+                resultRepository.save(result);
+            }
+        }
+    }
+}

--- a/src/main/java/com/rhkr8521/iccas_question/common/response/SuccessStatus.java
+++ b/src/main/java/com/rhkr8521/iccas_question/common/response/SuccessStatus.java
@@ -15,7 +15,7 @@ public enum SuccessStatus {
     SEND_QUESTION_SUCCESS(HttpStatus.OK, "문제 발송 성공"),
     SEND_QUESTION_ANSWER_YES(HttpStatus.OK, "정답 입니다"),
     SEND_QUESTION_ANSWER_NO(HttpStatus.OK, "오답 입니다"),
-
+    SEND_RESULT(HttpStatus.OK, "결과 발송 성공"),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
사용자 별 게임 결과를 전송하는 API를 구현했습니다.

테마 - 스테이지별 결과 정보)
1. 총 푼 문제 수
2. 총 맞은 문제 수
3. 직전에 플레이 했던 게임에서 맞은 수

1, 2스테이지는 10문제 / 3스테이지는 1문제가 진행됩니다.

유의사항 : 서버에서 회원정보를 관리하지 않아서 사용자가 처음으로 정답 확인 API를 호출했을때 result 테이블 초기값을 설정하도록 되어있어 정답 확인 API를 한번도 호출하지 않은 사용자가 결과 확인 API를 호출했을때 아래처럼 아무런 데이터가 전송 되지 않습니다. 이런 케이스의 예외처리가 필요합니다, 예를 들면 아래 같이 데이터가 없을경우 총 푼 문제 수, 총 맞은 문제 수, 최근에 맞은 문제 수 를 모두 0으로 보이도록 하는 방법 입니다.

{
    "status": 200,
    "success": true,
    "message": “결과 발송 성공”,
    "data": []
}
