### PR TITLE
[FIX] Change Send Result Feature

### DIFF
--- a/src/main/java/com/rhkr8521/iccas_question/api/answer/service/AnswerService.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/answer/service/AnswerService.java
@@ -26,7 +26,7 @@ public class AnswerService {
 
         boolean isCorrect = question.getAnswer().equalsIgnoreCase(userAnswer);
 
-        resultService.updateResult(userId, question.getTheme(), question.getStage(), isCorrect);
+        resultService.updateGameSet(userId, question.getTheme(), question.getStage(), isCorrect);
 
         Answer answer = Answer.builder()
                 .question(question)

--- a/src/main/java/com/rhkr8521/iccas_question/api/result/controller/ResultController.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/controller/ResultController.java
@@ -20,13 +20,13 @@ public class ResultController {
     private final ResultService resultService;
 
     @GetMapping("/api/result/{userId}")
-    public ResponseEntity<?> getResultsByTheme(@PathVariable String userId, @RequestParam String theme) {
-        List<ResultResponseDTO> resultResponseDtos = resultService.getResultsByTheme(userId, theme);
+    public ResponseEntity<?> getBestResultsByTheme(@PathVariable String userId, @RequestParam String theme) {
+        List<ResultResponseDTO> bestResults = resultService.getBestResults(userId, theme);
         return ResponseEntity.ok(ApiResponse.builder()
                 .status(SuccessStatus.SEND_RESULT.getStatusCode())
                 .success(true)
                 .message(SuccessStatus.SEND_RESULT.getMessage())
-                .data(resultResponseDtos)
+                .data(bestResults)
                 .build());
     }
 }

--- a/src/main/java/com/rhkr8521/iccas_question/api/result/domain/GameSet.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/domain/GameSet.java
@@ -1,0 +1,55 @@
+package com.rhkr8521.iccas_question.api.result.domain;
+
+import com.rhkr8521.iccas_question.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Entity
+@Builder(toBuilder = true)
+public class GameSet extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String userId;
+    private String theme;
+    private int firstStageRecord;
+    private int firstStageTotalCount;
+    private int secondStageRecord;
+    private int secondStageTotalCount;
+    private int thirdStageRecord;
+    private int thirdStageTotalCount;
+
+    public int getTotalCorrectAnswers() {
+        return firstStageRecord + secondStageRecord + thirdStageRecord;
+    }
+
+    public double getTotalAccuracy() {
+        return (firstStageRecord / 5.0) + (secondStageRecord / 5.0) + (thirdStageRecord / 1.0);
+    }
+
+    public GameSet updateFirstStageRecord(int increment) {
+        return this.toBuilder()
+                .firstStageRecord(this.firstStageRecord + increment)
+                .firstStageTotalCount(this.firstStageTotalCount + 1)
+                .build();
+    }
+
+    public GameSet updateSecondStageRecord(int increment) {
+        return this.toBuilder()
+                .secondStageRecord(this.secondStageRecord + increment)
+                .secondStageTotalCount(this.secondStageTotalCount + 1)
+                .build();
+    }
+
+    public GameSet updateThirdStageRecord(int increment) {
+        return this.toBuilder()
+                .thirdStageRecord(this.thirdStageRecord + increment)
+                .thirdStageTotalCount(this.thirdStageTotalCount + 1)
+                .build();
+    }
+}

--- a/src/main/java/com/rhkr8521/iccas_question/api/result/domain/Result.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/domain/Result.java
@@ -16,31 +16,7 @@ public class Result extends BaseTimeEntity {
     private Long id;
 
     private String userId;
-
     private String theme;
     private Long stage;
-
-    private int totalQuestions;
-    private int totalCorrectAnswers;
-
-    private int recentCorrectAnswers;
-    private int highCorrectAnswers;
-
-    public void incrementTotalQuestions() {
-        this.totalQuestions++;
-    }
-
-    public void incrementTotalCorrectAnswers() {
-        this.totalCorrectAnswers++;
-    }
-
-    public void updateRecentCorrectAnswers(int correctAnswers) {
-        this.recentCorrectAnswers = correctAnswers;
-    }
-
-    public void updateHighCorrectAnswers(int correctAnswers) {
-        if (correctAnswers > this.highCorrectAnswers) {
-            this.highCorrectAnswers = correctAnswers;
-        }
-    }
+    private int correctAnswers;
 }

--- a/src/main/java/com/rhkr8521/iccas_question/api/result/dto/ResultResponseDTO.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/dto/ResultResponseDTO.java
@@ -1,28 +1,13 @@
 package com.rhkr8521.iccas_question.api.result.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
 public class ResultResponseDTO {
     private String userId;
     private String theme;
     private Long stage;
-    private int totalQuestions;
-    private int totalCorrectAnswers;
-    private int recentCorrectAnswers;
-    private Integer highCorrectAnswers;
-
-    @Builder
-    public ResultResponseDTO(String userId, String theme, Long stage, int totalQuestions, int totalCorrectAnswers, int recentCorrectAnswers, Integer highCorrectAnswers) {
-        this.userId = userId;
-        this.theme = theme;
-        this.stage = stage;
-        this.totalQuestions = totalQuestions;
-        this.totalCorrectAnswers = totalCorrectAnswers;
-        this.recentCorrectAnswers = recentCorrectAnswers;
-        this.highCorrectAnswers = highCorrectAnswers;
-    }
+    private int correctAnswers;
 }

--- a/src/main/java/com/rhkr8521/iccas_question/api/result/repository/GameSetRepository.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/repository/GameSetRepository.java
@@ -1,0 +1,9 @@
+package com.rhkr8521.iccas_question.api.result.repository;
+
+import com.rhkr8521.iccas_question.api.result.domain.GameSet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface GameSetRepository extends JpaRepository<GameSet, Long> {
+    List<GameSet> findByUserIdAndTheme(String userId, String theme);
+}

--- a/src/main/java/com/rhkr8521/iccas_question/api/result/repository/ResultRepository.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/repository/ResultRepository.java
@@ -2,11 +2,9 @@ package com.rhkr8521.iccas_question.api.result.repository;
 
 import com.rhkr8521.iccas_question.api.result.domain.Result;
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.List;
+
 import java.util.Optional;
 
 public interface ResultRepository extends JpaRepository<Result, Long> {
     Optional<Result> findByUserIdAndThemeAndStage(String userId, String theme, Long stage);
-    boolean existsByUserId(String userId);
-    List<Result> findByUserIdAndTheme(String userId, String theme);
 }


### PR DESCRIPTION
게임 결과 전송 API 기능을 대폭 수정하였습니다.

- 사용자가 진행한 게임 플레이 중 모든 스테이즈 통틀어서 가장 정답률이 높은 기록을 발송하도록 변경하였습니다.

유의사항 : 서버에서 회원정보를 관리하지 않아서 사용자가 처음으로 정답 확인 API를 호출했을때 result 테이블 초기값을 설정하도록 되어있어 정답 확인 API를 한번도 호출하지 않은 사용자가 결과 확인 API를 호출했을때 아래와 같이 404 에러코드가 뜹니다. 이거에 대한 예외처리를 클라이언트에서 진행해야합니다.

{
    "status": 404,
    "success": false,
    "message": "해당 사용자는 게임 플레이 기록이 없습니다."
}