### PR TITLE
[FIX] Add create question feature using chatGPT API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-devtools'
 
 	// JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/rhkr8521/iccas_question/api/question/controller/QuestionController.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/question/controller/QuestionController.java
@@ -20,12 +20,17 @@ public class QuestionController {
     private final QuestionService questionService;
 
     @GetMapping("/api/question/{theme}")
-    public ApiResponse<List<QuestionDTO>> getQuestionsByThemeAndStage(@PathVariable String theme, @RequestParam Long stage) {
-        List<QuestionDTO> questions = questionService.getRandomQuestionsByThemeAndStage(theme, stage);
-        if (!questions.isEmpty()) {
-            return ApiResponse.success(SuccessStatus.SEND_QUESTION_SUCCESS, questions);
+    public ApiResponse<?> getQuestionsByThemeAndStage(@PathVariable String theme, @RequestParam Long stage) {
+        if (stage == 3L) {
+            QuestionDTO questionDTO = questionService.getChatGPTQuestion(theme);
+            return ApiResponse.success(SuccessStatus.SEND_QUESTION_SUCCESS, questionDTO);
         } else {
-            return ApiResponse.fail(ErrorStatus.NOT_FOUND_QUESTION.getStatusCode(), ErrorStatus.NOT_FOUND_QUESTION.getMessage());
+            List<QuestionDTO> questions = questionService.getRandomQuestionsByThemeAndStage(theme, stage);
+            if (!questions.isEmpty()) {
+                return ApiResponse.success(SuccessStatus.SEND_QUESTION_SUCCESS, questions);
+            } else {
+                return ApiResponse.fail(ErrorStatus.NOT_FOUND_QUESTION.getStatusCode(), ErrorStatus.NOT_FOUND_QUESTION.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/rhkr8521/iccas_question/api/question/dto/ChatGPTRequestDTO.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/question/dto/ChatGPTRequestDTO.java
@@ -1,0 +1,18 @@
+package com.rhkr8521.iccas_question.api.question.dto;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class ChatGPTRequestDTO {
+    private String model;
+    private List<MessageDTO> messages;
+
+    public ChatGPTRequestDTO(String model, String prompt) {
+        this.model = model;
+        this.messages =  new ArrayList<>();
+        this.messages.add(new MessageDTO("user", prompt));
+    }
+}

--- a/src/main/java/com/rhkr8521/iccas_question/api/question/dto/ChatGPTResponseDTO.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/question/dto/ChatGPTResponseDTO.java
@@ -1,0 +1,24 @@
+package com.rhkr8521.iccas_question.api.question.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatGPTResponseDTO {
+    private List<Choice> choices;
+
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Choice {
+        private int index;
+        private MessageDTO message;
+
+    }
+}

--- a/src/main/java/com/rhkr8521/iccas_question/api/question/dto/MessageDTO.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/question/dto/MessageDTO.java
@@ -1,0 +1,14 @@
+package com.rhkr8521.iccas_question.api.question.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageDTO {
+    private String role;
+    private String content;
+
+}

--- a/src/main/java/com/rhkr8521/iccas_question/api/question/service/QuestionService.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/question/service/QuestionService.java
@@ -1,14 +1,24 @@
 package com.rhkr8521.iccas_question.api.question.service;
 
 import com.rhkr8521.iccas_question.api.question.domain.Question;
+import com.rhkr8521.iccas_question.api.question.dto.ChatGPTRequestDTO;
+import com.rhkr8521.iccas_question.api.question.dto.ChatGPTResponseDTO;
 import com.rhkr8521.iccas_question.api.question.dto.QuestionDTO;
 import com.rhkr8521.iccas_question.api.question.repository.QuestionRepository;
+import com.rhkr8521.iccas_question.common.exception.InternalServerError;
+import com.rhkr8521.iccas_question.common.exception.NotFoundException;
+import com.rhkr8521.iccas_question.common.response.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
@@ -18,6 +28,15 @@ public class QuestionService {
     private final QuestionRepository questionRepository;
     private final Random random = new Random();
 
+    @Autowired
+    private final RestTemplate restTemplate;
+
+    @Value("${openai.api.model}")
+    private String model;
+
+    @Value("${openai.api.url}")
+    private String apiURL;
+
     public List<QuestionDTO> getRandomQuestionsByThemeAndStage(String theme, Long stage) {
         List<Question> questions = questionRepository.findByThemeAndStage(theme, stage);
         if (questions.isEmpty()) {
@@ -26,8 +45,56 @@ public class QuestionService {
 
         Collections.shuffle(questions);
         return questions.stream()
-                .limit(10)
+                .limit(5)
                 .map(question -> new QuestionDTO(question.getQuestionId(), question.getContent()))
                 .collect(Collectors.toList());
+    }
+
+    public QuestionDTO getChatGPTQuestion(String theme) {
+        String prompt = getPromptByTheme(theme);
+        ChatGPTRequestDTO request = new ChatGPTRequestDTO(model, prompt);
+        ChatGPTResponseDTO response = restTemplate.postForObject(apiURL, request, ChatGPTResponseDTO.class);
+
+        if (response != null && !response.getChoices().isEmpty()) {
+            ChatGPTResponseDTO.Choice choice = response.getChoices().get(0);
+            String content = choice.getMessage().getContent();
+
+            Pattern pattern = Pattern.compile("\\[sentence: (.*?), changed_word: (.*?), original_word: (.*?)\\]");
+            Matcher matcher = pattern.matcher(content);
+
+            if (matcher.find()) {
+                String sentence = matcher.group(1);
+                String changedWord = matcher.group(2);
+                String originalWord = matcher.group(3);
+
+                Question question = Question.builder()
+                        .content(sentence + "+" + originalWord + "+" + changedWord)
+                        .answer(changedWord)
+                        .theme(theme)
+                        .stage(3L)
+                        .build();
+
+                question = questionRepository.save(question);
+
+                return new QuestionDTO(question.getQuestionId(), question.getContent());
+            } else {
+                throw new InternalServerError(ErrorStatus.CHATGPT_INCORRECT_RESPONSE + content);
+            }
+        } else {
+            throw new InternalServerError(ErrorStatus.CHATGPT_RESPONSE_FAIL.getMessage());
+        }
+    }
+
+    private String getPromptByTheme(String theme) {
+        switch (theme) {
+            case "carousel":
+                return "You are an expert in treating dyslexia. Write one sentence for the Dyslexia Therapy Reading Practice using the theme of your experience at an amusement park carousel. You can write it wrong with one similar words on purpose. Don't change the word conversion too much. Please print it out in the form of [sentence: your_sentence, changed_word: your_changed_word, original_word: your_original_word]";
+            case "ferris_wheel":
+                return "You are an expert in treating dyslexia. Write one sentence for the Dyslexia Therapy Reading Practice using the theme of your experience at an amusement park ferris wheel. You can write it wrong with one similar words on purpose. Don't change the word conversion too much. Please print it out in the form of [sentence: your_sentence, changed_word: your_changed_word, original_word: your_original_word]";
+            case "roller_coaster":
+                return "You are an expert in treating dyslexia. Write one sentence for the Dyslexia Therapy Reading Practice using the theme of your experience at an amusement park roller coaster. You can write it wrong with one similar words on purpose. Don't change the word conversion too much. Please print it out in the form of [sentence: your_sentence, changed_word: your_changed_word, original_word: your_original_word]";
+            default:
+                throw new NotFoundException(ErrorStatus.NOT_FOUND_THEME.getMessage());
+        }
     }
 }

--- a/src/main/java/com/rhkr8521/iccas_question/common/config/OpenAIConfig.java
+++ b/src/main/java/com/rhkr8521/iccas_question/common/config/OpenAIConfig.java
@@ -1,0 +1,22 @@
+package com.rhkr8521.iccas_question.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class OpenAIConfig {
+    @Value("${openai.api.key}")
+    private String openAiKey;
+
+    @Bean
+    public RestTemplate template(){
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().add("Authorization", "Bearer " + openAiKey);
+            return execution.execute(request, body);
+        });
+        return restTemplate;
+    }
+}

--- a/src/main/java/com/rhkr8521/iccas_question/common/exception/InternalServerError.java
+++ b/src/main/java/com/rhkr8521/iccas_question/common/exception/InternalServerError.java
@@ -1,0 +1,13 @@
+package com.rhkr8521.iccas_question.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InternalServerError extends BaseException{
+    public InternalServerError() {
+        super(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    public InternalServerError(String message) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, message);
+    }
+}

--- a/src/main/java/com/rhkr8521/iccas_question/common/response/ErrorStatus.java
+++ b/src/main/java/com/rhkr8521/iccas_question/common/response/ErrorStatus.java
@@ -19,13 +19,17 @@ public enum ErrorStatus {
      * 404 NOT_FOUND
      */
     NOT_FOUND_QUESTION(HttpStatus.NOT_FOUND, "해당 문제를 찾을 수 없습니다."),
+    NOT_FOUND_THEME(HttpStatus.NOT_FOUND, "해당 테마를 찾을 수 없습니다."),
 
     /**
      * 500 SERVER_ERROR
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 서버 에러가 발생했습니다."),
     BAD_GATEWAY_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "일시적인 에러가 발생하였습니다.\n잠시 후 다시 시도해주세요!"),
-    Initial_Result_Fail(HttpStatus.INTERNAL_SERVER_ERROR, "결과 초기값 설정에 에러가 발생했습니다.");
+    Initial_Result_Fail(HttpStatus.INTERNAL_SERVER_ERROR, "결과 초기값 설정에 에러가 발생했습니다."),
+    CHATGPT_RESPONSE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "chatGPT API 통신에 실패했습니다."),
+    CHATGPT_INCORRECT_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "chatGPT API 응답이 비정상 입니다, 응답내용 : "),
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
문제 발송 API 에서 3스테이지의 문제를 요청 할 경우 해당 테마에 맞는 문장을 chatGPT API 를 사용하여 생성하는 기능을 추가하였습니다.

% 긴급 변경사항 24.07.10 % :  1,2 스테이지의 발송 문제 수를 10개에서 5개로 조정하였습니다. - 어제 회의 내용

유의사항 : 3단계의 문제 발송 같은 경우 엔드포인트로 요청이 들어 올 경우 서버 단에서 chatGPT API를 통해 문제를 생성합니다. 예시를 들어 [https://{URL}/api/question/carousel?stage=](https://worderland.kro.kr/api/question/carousel?stage=1)3 이 URL을 활용하여 서버에 요청했을경우 아래와 같이 응답이 들어옵니다. 여기서 content 내용을 + 기준으로 슬라이스를 해야합니다. 맨 앞에있는 문장은 변형된 단어가 포함된 문장이고, 가운데에 있는 단어가 원래 정답 단어, 오른쪽에 있는 단어가 변형된 단어 입니다. 이에 맞게 유니티 단에서 게임 풀이 로직을 적절하게 적용해야합니다.

{
    "status": 200,
    "success": true,
    "message": "문제 발송 성공",
    "data": {
        "questionId": 18,
        "content": "I remember trying to mount the colorful horse on the charming carousel+count+mount"
    }
}