### PR TITLE
[FEAT] Create Second Stage Question using ChatGPT Image API

### DIFF
--- a/src/main/java/com/rhkr8521/iccas_question/api/question/controller/QuestionController.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/question/controller/QuestionController.java
@@ -24,6 +24,9 @@ public class QuestionController {
         if (stage == 3L) {
             QuestionDTO questionDTO = questionService.getChatGPTQuestion(theme);
             return ApiResponse.success(SuccessStatus.SEND_QUESTION_SUCCESS, questionDTO);
+        } else if (stage == 2L) {
+            List<QuestionDTO> questions = questionService.getChatGPTImageQuestions(theme);
+            return ApiResponse.success(SuccessStatus.SEND_QUESTION_SUCCESS, questions);
         } else {
             List<QuestionDTO> questions = questionService.getRandomQuestionsByThemeAndStage(theme, stage);
             if (!questions.isEmpty()) {

--- a/src/main/java/com/rhkr8521/iccas_question/api/question/domain/Question.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/question/domain/Question.java
@@ -15,6 +15,7 @@ public class Question extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long questionId;
 
+    @Column(length = 1000)
     private String content;
     private String answer;
     private String theme;

--- a/src/main/java/com/rhkr8521/iccas_question/api/question/dto/ChatGPTRequestImageDTO.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/question/dto/ChatGPTRequestImageDTO.java
@@ -1,0 +1,21 @@
+package com.rhkr8521.iccas_question.api.question.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatGPTRequestImageDTO{
+
+    private String prompt;
+    private int n;
+    private String size;
+
+    @Builder
+    public ChatGPTRequestImageDTO(String prompt, int n, String size) {
+        this.prompt = prompt;
+        this.n = n;
+        this.size = size;
+    }
+}

--- a/src/main/java/com/rhkr8521/iccas_question/api/question/dto/ChatGPTResponseImageDTO.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/question/dto/ChatGPTResponseImageDTO.java
@@ -1,0 +1,33 @@
+package com.rhkr8521.iccas_question.api.question.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ChatGPTResponseImageDTO {
+
+    private long created;
+    private List<ImageURL> data;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    public static class ImageURL {
+        private String url;
+
+        @Builder
+        public ImageURL(String url) {
+            this.url = url;
+        }
+    }
+
+    @Builder
+    public ChatGPTResponseImageDTO(long created, List<ImageURL> data) {
+        this.created = created;
+        this.data = data;
+    }
+}


### PR DESCRIPTION
두번째 스테이지 문제 에서 ChatGPT 이미지 생성 API를 활용한 그림 단어 찾기 문제 생성 기능을 구현하였습니다.