### PR TITLE
[FIX] Change Filtering using UpdateAt

### DIFF
--- a/src/main/java/com/rhkr8521/iccas_question/api/result/service/ResultService.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/service/ResultService.java
@@ -144,7 +144,7 @@ public class ResultService {
         }
 
         Map<LocalDate, List<GameSet>> gameSetByDate = gameSets.stream()
-                .collect(Collectors.groupingBy(gameSet -> gameSet.getCreatedAt().toLocalDate()));
+                .collect(Collectors.groupingBy(gameSet -> gameSet.getUpdatedAt().toLocalDate()));
 
         return gameSetByDate.entrySet().stream()
                 .map(entry -> {


### PR DESCRIPTION
사용자 별 게임 보고서 반환 API에서 createAt이 아닌 UpdateAt으로 필터링 하도록 수정하였습니다.