### PR TITLE
[FIX] Fix error that include zero in the mean calculation

### DIFF
--- a/src/main/java/com/rhkr8521/iccas_question/api/result/service/ResultService.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/result/service/ResultService.java
@@ -157,13 +157,19 @@ public class ResultService {
                                         .collect(Collectors.toList());
 
                                 double firstStageBestRecord = themeGameSets.stream().mapToInt(GameSet::getFirstStageRecord).max().orElse(0);
-                                double firstStageAverageRecord = themeGameSets.stream().mapToInt(GameSet::getFirstStageRecord).average().orElse(0.0);
+                                double firstStageAverageRecord = themeGameSets.stream()
+                                        .filter(gs -> gs.getFirstStageTotalCount() > 0)
+                                        .mapToInt(GameSet::getFirstStageRecord).average().orElse(0.0);
 
                                 double secondStageBestRecord = themeGameSets.stream().mapToInt(GameSet::getSecondStageRecord).max().orElse(0);
-                                double secondStageAverageRecord = themeGameSets.stream().mapToInt(GameSet::getSecondStageRecord).average().orElse(0.0);
+                                double secondStageAverageRecord = themeGameSets.stream()
+                                        .filter(gs -> gs.getSecondStageTotalCount() > 0)
+                                        .mapToInt(GameSet::getSecondStageRecord).average().orElse(0.0);
 
                                 double thirdStageBestRecord = themeGameSets.stream().mapToInt(GameSet::getThirdStageRecord).max().orElse(0);
-                                double thirdStageAverageRecord = themeGameSets.stream().mapToInt(GameSet::getThirdStageRecord).average().orElse(0.0);
+                                double thirdStageAverageRecord = themeGameSets.stream()
+                                        .filter(gs -> gs.getThirdStageTotalCount() > 0)
+                                        .mapToInt(GameSet::getThirdStageRecord).average().orElse(0.0);
 
                                 double totalBestRecord = firstStageBestRecord + secondStageBestRecord + thirdStageBestRecord;
                                 double totalAverageRecord = firstStageAverageRecord + secondStageAverageRecord + thirdStageAverageRecord;


### PR DESCRIPTION
사용자 게임 결과 반환 API에서 빈 게임셋을 포함하여 평균을 계산하는 오류를 해결하였습니다.