### PR TITLE
[FIX] Fix Carousel Theme Second Stage Question Send

### DIFF
--- a/src/main/java/com/rhkr8521/iccas_question/api/question/service/QuestionService.java
+++ b/src/main/java/com/rhkr8521/iccas_question/api/question/service/QuestionService.java
@@ -97,6 +97,22 @@ public class QuestionService {
     }
 
     public List<QuestionDTO> getChatGPTImageQuestions(String theme) {
+        if ("carousel".equals(theme)) {
+            List<Question> questions = questionRepository.findByThemeAndStage(theme, 2L).stream()
+                    .filter(question -> !question.getContent().startsWith("https"))
+                    .collect(Collectors.toList());
+
+            if (questions.size() < 5) {
+                throw new NotFoundException(ErrorStatus.NOT_FOUND_QUESTION.getMessage());
+            }
+
+            Collections.shuffle(questions);
+            return questions.stream()
+                    .limit(5)
+                    .map(question -> new QuestionDTO(question.getQuestionId(), question.getContent()))
+                    .collect(Collectors.toList());
+        }
+
         List<Question> questions = questionRepository.findByThemeAndStage(theme, 2L).stream()
                 .filter(question -> !question.getContent().startsWith("https"))
                 .collect(Collectors.toList());


### PR DESCRIPTION
Carousel 테마에서 2스테이지의 경우 chatGPT 이미지 생성이 아닌 일반 문제 5개만 가져오도록 수정하였습니다.